### PR TITLE
updated getAddon to return console error rather than throwing a new error

### DIFF
--- a/src/utils/getAddon.js
+++ b/src/utils/getAddon.js
@@ -10,7 +10,7 @@ switch (os.type()) {
     infofile = require("../addons/infofile/linux64/infofile-linux64.node");
     break;
   default:
-    throw new Error(
+    console.error(
       "Unsupported OS type: " +
         os.type() +
         ". Infofile only supports Windows and Linux."

--- a/src/utils/getAddon.js
+++ b/src/utils/getAddon.js
@@ -10,11 +10,18 @@ switch (os.type()) {
     infofile = require("../addons/infofile/linux64/infofile-linux64.node");
     break;
   default:
-    console.error(
+    // unsupported os type so return object that has basic functions stubbed out to return empty values and throw an appropriate error message
+    const errorMessage =
       "Unsupported OS type: " +
-        os.type() +
-        ". Infofile only supports Windows and Linux."
-    );
+      os.type() +
+      ". Infofile only supports Windows and Linux.";
+    infofile = {
+      delete: () => {},
+      getError: () => {
+        return errorMessage;
+      },
+    };
+    console.error(errorMessage);
 }
 
 // export the infofile addon


### PR DESCRIPTION
Updated error when getting an addon for an OS that is not supported to be a console error rather than a hard error.

This change was made to improve the development environment for developers that are not using a support OS. Previous to this change developers would have to comment out code in order to run services that used this library as the code would error. 

I'll need to do a release for this to go live. There are some other open issues, that I'll probably bundle this with. 


## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Assigned to me.
- [x] Relevant tags added.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
